### PR TITLE
 FEATURE(beanstalkd): Add a watch-file and location

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,4 +16,11 @@ openio_beanstalkd_binlogsize: 10240000
 
 openio_beanstalkd_volume: "/var/lib/oio/sds/{{ openio_beanstalkd_namespace }}/{{ openio_beanstalkd_servicename }}"
 openio_beanstalkd_provision_only: false
+
+openio_beanstalkd_location: "{{ ansible_hostname }}.{{ openio_beanstalkd_serviceid }}"
+openio_beanstalkd_slots:
+  "{{ [ openio_beanstalkd_type, openio_beanstalkd_type ~ '-' ~ openio_beanstalkd_location.split('.')[:-2] \
+  | join('-') ] \
+  if openio_beanstalkd_location.split('.') | length > 2 \
+  else [ openio_beanstalkd_type ] }}"
 ...

--- a/docker-tests/requirements.yml
+++ b/docker-tests/requirements.yml
@@ -1,17 +1,17 @@
 ---
 - src: https://github.com/open-io/ansible-role-openio-users.git
-  version: master
+  version: "19.04"
   name: users
 
 - src: https://github.com/open-io/ansible-role-openio-gridinit.git
-  version: master
+  version: "19.04"
   name: gridinit
 
 - src: https://github.com/open-io/ansible-role-openio-repository.git
-  version: master
+  version: "19.04"
   name: repo
 
 - src: https://github.com/open-io/ansible-role-openio-namespace.git
-  version: master
+  version: "19.04"
   name: namespace
 ...

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -8,9 +8,6 @@
     - role: users
     - role: repo
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.04"
     - role: namespace
       openio_namespace_name: "{{ NS }}"
     - role: gridinit

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,7 @@
     - path: "/etc/gridinit.d/{{ openio_beanstalkd_namespace }}"
     - path: "{{ openio_beanstalkd_sysconfig_dir }}/{{ openio_beanstalkd_servicename }}"
     - path: "{{ openio_beanstalkd_volume }}"
+    - path: "/etc/oio/sds/{{ openio_beanstalkd_namespace }}/watch"
     - path: "/var/log/oio/sds/{{ openio_beanstalkd_namespace }}/{{ openio_beanstalkd_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0750"
@@ -44,6 +45,8 @@
     - src: "gridinit_beanstalkd.conf.j2"
       dest: "{{ openio_beanstalkd_gridinit_dir }}/{{ openio_beanstalkd_gridinit_file_prefix }}\
         {{ openio_beanstalkd_servicename }}.conf"
+    - src: "watch-beanstalkd.yml.j2"
+      dest: "{{ openio_beanstalkd_sysconfig_dir }}/watch/{{ openio_beanstalkd_servicename }}.yml"
   register: _beanstalkd_conf
 
 - name: restart beanstalkd

--- a/templates/watch-beanstalkd.yml.j2
+++ b/templates/watch-beanstalkd.yml.j2
@@ -1,0 +1,19 @@
+# {{ ansible_managed }}
+---
+host: {{ openio_beanstalkd_bind_address }}
+port: {{ openio_beanstalkd_bind_port }}
+type: beanstalkd
+{% if openio_beanstalkd_location | ipaddr %}
+location: {{ openio_beanstalkd_location | replace(".", "-") }}
+{% else %}
+location: {{ openio_beanstalkd_location }}
+{% endif %}
+checks:
+  - {type: tcp}
+stats:
+  - {type: beanstalkd}
+  - {type: volume, path: {{ openio_beanstalkd_volume }}}
+  - {type: system}
+slots:
+  {{ openio_beanstalkd_slots | to_nice_yaml | indent(2) }}
+...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 openio_beanstalkd_sysconfig_dir: "/etc/oio/sds/{{ openio_beanstalkd_namespace }}"
 openio_beanstalkd_servicename: "beanstalkd-{{ openio_beanstalkd_serviceid }}"
+openio_beanstalkd_type: beanstalkd
 
 openio_beanstalkd_definition_file: >
   "{{ openio_beanstalkd_sysconfig_dir }}/


### PR DESCRIPTION
 ##### SUMMARY

In this release, the conscience is scoring the beanstalkds

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```console
root@7300b044a6c3:/# cat /etc/oio/sds/TRAVIS/watch/beanstalkd-0.yml
---
host: 172.17.0.5
port: 6014
type: beanstalkd
location: 7300b044a6c3.0
checks:
  - {type: tcp}
stats:
  - {type: volume, path: /var/lib/oio/sds/TRAVIS/beanstalkd-0}
  - {type: system}
slots:
  - beanstalkd

...
```
