### PR TITLE
CHANGE(beanstalkd): Ensure service is started or restarted at the end…

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -4,15 +4,17 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: users
     - role: repo
       openio_repository_no_log: false
-    - role: namespace
-      openio_namespace_name: "{{ NS }}"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
       openio_gridinit_per_ns: true
+    - role: namespace
+      openio_namespace_name: "{{ NS }}"
     - role: role_under_test
       openio_beanstalkd_namespace: "{{ NS }}"
       openio_beanstalkd_bind_address: "{{ ansible_default_ipv4.address }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,12 +49,36 @@
       dest: "{{ openio_beanstalkd_sysconfig_dir }}/watch/{{ openio_beanstalkd_servicename }}.yml"
   register: _beanstalkd_conf
 
-- name: restart beanstalkd
+- name: "restart beanstalkd to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_beanstalkd_namespace }}-{{ openio_beanstalkd_servicename }}
+  register: _restart_beanstalkd
   when:
-    - _beanstalkd_conf.changed
+    - _beanstalkd_conf is changed
     - not openio_beanstalkd_provision_only
   tags: configure
+
+- block:
+    - name: "Ensure beanstalkd is started"
+      command: gridinit_cmd start {{ openio_beanstalkd_namespace }}-{{ openio_beanstalkd_servicename }}
+      register: _start_beanstalkd
+      changed_when: '"Success" in _start_beanstalkd.stdout'
+      when:
+        - not openio_beanstalkd_provision_only
+        - _restart_beanstalkd is skipped
+      tags: configure
+
+    - name: check beanstalkd
+      wait_for:
+        host: "{{ openio_beanstalkd_bind_address }}"
+        port: "{{ openio_beanstalkd_bind_port }}"
+      register: _beanstalkd_check
+      retries: 3
+      delay: 5
+      until: _beanstalkd_check is success
+      changed_when: false
+      when:
+        - not openio_beanstalkd_provision_only
+  when: openio_bootstrap | d(false)
 ...


### PR DESCRIPTION
… of role

 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION