### PR TITLE
CHANGE(beanstalkd): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An Ansible role for beanstalkd. Specifically, the responsibilities of this role 
 | `openio_beanstalkd_provision_only` | `false` | ... |
 | `openio_beanstalkd_serviceid` | `"0"` | ... |
 | `openio_beanstalkd_volume` | `"/var/lib/oio/sds/{{ openio_beanstalkd_namespace }}/beanstalkd-{{ openio_beanstalkd_serviceid }}"` | ... |
-
+| `openio_beanstalkd_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ openio_beanstalkd_binlogsize: 10240000
 
 openio_beanstalkd_volume: "/var/lib/oio/sds/{{ openio_beanstalkd_namespace }}/{{ openio_beanstalkd_servicename }}"
 openio_beanstalkd_provision_only: false
+openio_beanstalkd_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 
 openio_beanstalkd_location: "{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}\
   {{ openio_location_server | default (ansible_hostname ~ '.') }}{{ openio_beanstalkd_serviceid }}"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_beanstalkd_package_upgrade else 'present' }}"
   with_items: "{{ beanstalkd_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_beanstalkd_package_upgrade else 'present' }}"
   with_items: "{{ beanstalkd_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION