### PR TITLE
CHANGE(beanstalkd): move variables from `vars` to `default`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,3 @@
-# roles/beanstalkd/defaults/main.yml
 ---
 openio_beanstalkd_namespace: "{{ namespace | default('OPENIO') }}"
 openio_beanstalkd_serviceid: "{{ 0 + openio_legacy_serviceid | d(0) | int }}"
@@ -25,4 +24,12 @@ openio_beanstalkd_slots:
   | join('-') ] \
   if openio_beanstalkd_location.split('.') | length > 2 \
   else [ openio_beanstalkd_type ] }}"
+
+openio_beanstalkd_sysconfig_dir: "/etc/oio/sds/{{ openio_beanstalkd_namespace }}"
+openio_beanstalkd_servicename: "beanstalkd-{{ openio_beanstalkd_serviceid }}"
+openio_beanstalkd_type: beanstalkd
+
+openio_beanstalkd_definition_file: >
+  "{{ openio_beanstalkd_sysconfig_dir }}/
+  {{ openio_beanstalkd_servicename }}/{{ openio_beanstalkd_servicename }}.conf"
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,9 +1,2 @@
 ---
-openio_beanstalkd_sysconfig_dir: "/etc/oio/sds/{{ openio_beanstalkd_namespace }}"
-openio_beanstalkd_servicename: "beanstalkd-{{ openio_beanstalkd_serviceid }}"
-openio_beanstalkd_type: beanstalkd
-
-openio_beanstalkd_definition_file: >
-  "{{ openio_beanstalkd_sysconfig_dir }}/
-  {{ openio_beanstalkd_servicename }}/{{ openio_beanstalkd_servicename }}.conf"
 ...


### PR DESCRIPTION
 ##### SUMMARY
in `vars` should only remain variables that must be fixed.
All the others must be set in `defaults` (almost all variables).

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION