### PR TITLE
CHANGE(beanstalk): Set the bind_interface to openio_bind_interface by…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ openio_beanstalkd_serviceid: "{{ 0 + openio_legacy_serviceid | d(0) | int }}"
 openio_beanstalkd_gridinit_dir: "{{ openio_gridinit_d | d('/etc/gridinit.d/') }}"
 openio_beanstalkd_gridinit_file_prefix: "{{ openio_beanstalkd_namespace }}-"
 
-openio_beanstalkd_bind_interface: "{{ ansible_default_ipv4.alias }}"
+openio_beanstalkd_bind_interface: "{{ openio_bind_interface | d(ansible_default_ipv4.alias) }}"
 openio_beanstalkd_bind_address: "{{ openio_bind_address \
   | default(hostvars[inventory_hostname]['ansible_' + openio_beanstalkd_bind_interface]['ipv4']['address']) }}"
 openio_beanstalkd_bind_port: 6014


### PR DESCRIPTION
… default

 ##### SUMMARY

As bind_address, a good default is openio_bind_interface

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION